### PR TITLE
Add displayName to React class

### DIFF
--- a/InlineEdit.js
+++ b/InlineEdit.js
@@ -37,7 +37,7 @@ var propTypes = {
 };
 
 var InlineEdit = React.createClass({
-
+  displayName: 'InlineEdit',
   propTypes: propTypes,
 
   // Default props


### PR DESCRIPTION
By setting an explicit `displayName`, the InlineEdit component will be correctly named when viewed from the React Dev Tools. I think this is normally done implicitly when [in a `.jsx` file](https://facebook.github.io/react/docs/jsx-in-depth.html#the-transform) or when using ES6 classes, but as this component doesn't fall into either category it just shows up as "<No display name [...] />" in the dev tools currently.
